### PR TITLE
Fixed return typo on sample controller on entity framework page

### DIFF
--- a/docs/development/entity-framework.md
+++ b/docs/development/entity-framework.md
@@ -31,10 +31,10 @@ public class FoodController : GraphController
     public FoodController(AppDbContext context){}
 
     [QueryRoot]
-    public IPastry SearchMeat(string name){}
+    public IFood SearchMeat(string name){}
 
     [QueryRoot]
-    public IPastry SearchVeggies(string name){}
+    public IFood SearchVeggies(string name){}
 }
 ```
 


### PR DESCRIPTION
* Changed `IPastry` to `IFood` to be more in line with method names