### PR TITLE
Updated Monkier Pills to indicate new build targets.

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -10,8 +10,8 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: yarn
@@ -22,7 +22,7 @@ jobs:
         run: yarn build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.BOT_DEPLOYMENT_TOKEN }}          
           publish_dir: ./build

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -12,8 +12,8 @@ jobs:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: yarn

--- a/docs/development/unit-testing.md
+++ b/docs/development/unit-testing.md
@@ -5,12 +5,12 @@ sidebar_label: Unit Testing
 sidebar_position: 1
 ---
 
-<span className="pill">.NET 6+</span>
+<span className="pill">.NET 8+</span>
 <br/>
 <br/>
 
 :::info
-Your test projects must target .NET 6 or greater to use the test framework
+Your test projects must target .NET 8 or greater to use the test framework
 :::
 
 GraphQL ASP.NET has more than `3500 unit tests and 91% code coverage`. All the internal integration tests are powered by a framework designed to quickly build a configurable, fully mocked server instance to perform a query against the runtime. It may be helpful to use and extend the framework to test your own controllers.

--- a/docs/quick/overview.md
+++ b/docs/quick/overview.md
@@ -10,7 +10,7 @@ Use the menus on the left to navigate through the documentation. You do not need
 
 ## Nuget & Installation
 
-<span className="pill">.NET Standard 2.0</span> <span className="pill">.NET 6</span> <span className="pill">.NET 7</span> <span className="pill">.NET 8</span> <br/><br/>
+<span className="pill">.NET Standard 2.0</span> <span className="pill">.NET 8</span> <span className="pill">.NET 9</span> <br/><br/>
 
 The library is available on [nuget](https://www.nuget.org/packages/GraphQL.AspNet/) and can be added to your project via the conventional means.
 

--- a/docs/server-extensions/multipart-requests.md
+++ b/docs/server-extensions/multipart-requests.md
@@ -5,12 +5,12 @@ sidebar_label: File Uploads & Batching
 sidebar_position: 0
 ---
 
-<span className="pill">.NET 6+</span>
+<span className="pill">.NET 8+</span>
 
 ## Multipart Request Specification
 GraphQL ASP.NET provides built in support for batch query processing and file uploads via an implementation of the [GraphQL Multipart Request Specification](https://github.com/jaydenseric/graphql-multipart-request-spec).
 
-This extension requires a minimum version of `v1.2.0` of the main library and you must target .NET 6 or later. This extension will not work with the .NET standard implementation.
+This extension requires a minimum version of `v1.2.0` of the main library and you must target .NET 8 or later. This extension will not work with the .NET standard implementation.
 
 :::info
 This document covers how to submit a batch query and upload files that conform to the above specification. It provides sample curl requests that would be accepted for the given sample code but does not explain in detail the various form fields required to complete a request. It is highly recommended to use a [supported client](https://github.com/jaydenseric/graphql-multipart-request-spec#client) when enabling this server extension.

--- a/docs/types/scalars.md
+++ b/docs/types/scalars.md
@@ -33,7 +33,7 @@ GraphQL ASP.NET has 20 built in scalar types.
 | UShort         | System.UInt16          | Number              |
 
 :::info 
- You must target .NET 6.0 or later to use `DateOnly` and `TimeOnly`
+ You must target .NET 8.0 or later to use `DateOnly` and `TimeOnly`
 :::
 
 ## Input Value Resolution

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ function HomepageHeader() {
   return (
     <header className={clsx(styles.heroBanner)}>
       <div className="container">
-        <h1 className="hero__title">{siteConfig.title} <span className="pill-header pill-small">.NET 6+</span></h1>
+        <h1 className="hero__title">{siteConfig.title} <span className="pill-header pill-small">.NET 8+</span></h1>
         <div className={styles.buttons} >
           <div className={clsx("row", styles["main-buttons"])}>
             <div>


### PR DESCRIPTION
* Removed references to .NET 6
* Added references, where necessary, for .NET 9