### PR TITLE
Bug Fix Version number for OneOf directive support

### DIFF
--- a/docs/advanced/input-unions.md
+++ b/docs/advanced/input-unions.md
@@ -171,4 +171,4 @@ The `ValueOrDefault()` method will return a type of the fallback value, NOT of t
 
 
 ## Support
-Input Unions are supported in *GraphQL ASP.NET version 1.6* or later
+Input Unions are supported in *GraphQL ASP.NET version 1.5* or later


### PR DESCRIPTION
* Fixed the version for `@oneOf` support to be `v1.5.x` (previously 1.6)